### PR TITLE
修复ssrf漏洞

### DIFF
--- a/contact-center/app/src/main/java/com/cskefu/cc/controller/resource/MediaController.java
+++ b/contact-center/app/src/main/java/com/cskefu/cc/controller/resource/MediaController.java
@@ -44,6 +44,7 @@ import org.springframework.web.multipart.MultipartFile;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
+import java.util.regex.Pattern;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -98,6 +99,9 @@ public class MediaController extends Handler {
     @Menu(type = "resouce", subtype = "image", access = true)
     public void url(HttpServletResponse response, @Valid String url) throws IOException {
         if (StringUtils.isBlank(url)) {
+            return;
+        }
+        if(!Pattern.matches("^https?://.*/.*$", url)) { //只允许http/https协议
             return;
         }
         byte[] data = new byte[1024];


### PR DESCRIPTION
<!--- 在标题中简略说明问题 -->

## 描述
url过滤不严导致的ssrf漏洞

## 解决的问题
解决掉ssrf漏洞造成的任意文件读取

## 测试情况
存在漏洞的情况如下图，以demo站为例

## 截屏
![image](https://user-images.githubusercontent.com/105204993/198297541-0ce10cb7-91c1-4145-affc-a9b083126d5a.png)

## 变更的类型
<!--- 变更有哪些特点，添加 `x` 到下面的对应项目中: -->
- [x] 解决Bug
- [ ] 新功能（不影响其他功能）
- [ ] 对其他功能有影响

## 检查:
<!--- 检查下面，各项，添加 `x` 到下面的对应项目中: -->
- [ ] 我的变更和代码规范一致
- [ ] 我的变更需要更新文档
- [ ] 我已经更新了对应的文档
- [ ] 我增加的代码有单元测试
- [ ] 所有单元测试都能通过
