### PR TITLE
fix issue781:cwe-613

### DIFF
--- a/contact-center/app/src/main/java/com/cskefu/cc/controller/admin/UsersController.java
+++ b/contact-center/app/src/main/java/com/cskefu/cc/controller/admin/UsersController.java
@@ -38,6 +38,7 @@ import com.cskefu.cc.persistence.repository.PbxHostRepository;
 import com.cskefu.cc.persistence.repository.RoleRepository;
 import com.cskefu.cc.persistence.repository.UserRepository;
 import com.cskefu.cc.persistence.repository.UserRoleRepository;
+import com.cskefu.cc.proxy.AgentSessionProxy;
 import com.cskefu.cc.proxy.OrganProxy;
 import com.cskefu.cc.proxy.UserProxy;
 import com.cskefu.cc.util.Menu;
@@ -163,6 +164,9 @@ public class UsersController extends Handler {
                 organUserRes.delete(organUsers);
 
                 userRepository.delete(dbUser);
+
+                AgentSessionProxy agentSessionProxy = MainContext.getContext().getBean(AgentSessionProxy.class);
+                agentSessionProxy.deleteUserSession(dbUser.getId(), dbUser.getOrgi());
             }
         } else {
             msg = "admin_user_not_exist";

--- a/contact-center/app/src/main/java/com/cskefu/cc/interceptor/UserInterceptorHandler.java
+++ b/contact-center/app/src/main/java/com/cskefu/cc/interceptor/UserInterceptorHandler.java
@@ -24,6 +24,7 @@ import com.cskefu.cc.model.Dict;
 import com.cskefu.cc.model.Organ;
 import com.cskefu.cc.model.SystemConfig;
 import com.cskefu.cc.model.User;
+import com.cskefu.cc.proxy.AgentSessionProxy;
 import com.cskefu.cc.proxy.OrganProxy;
 import com.cskefu.cc.proxy.UserProxy;
 import com.cskefu.cc.util.Menu;
@@ -51,6 +52,15 @@ public class UserInterceptorHandler extends HandlerInterceptorAdapter {
         boolean filter = false;
         User user = (User) request.getSession(true).getAttribute(Constants.USER_SESSION_NAME);
         Organ organ = (Organ) request.getSession(true).getAttribute(Constants.ORGAN_SESSION_NAME);
+
+        if(user != null){
+            AgentSessionProxy agentSessionProxy = MainContext.getContext().getBean(AgentSessionProxy.class);
+            if(agentSessionProxy.isInvalidSessionId(user.getId(),MainUtils.getContextID(request.getSession().getId()),user.getOrgi())){
+                request.getSession().invalidate();
+                response.sendRedirect("/login.html");
+                return false;
+            }
+        }
 
         if (handler instanceof HandlerMethod) {
             HandlerMethod handlerMethod = (HandlerMethod) handler;

--- a/contact-center/app/src/main/java/com/cskefu/cc/proxy/AgentSessionProxy.java
+++ b/contact-center/app/src/main/java/com/cskefu/cc/proxy/AgentSessionProxy.java
@@ -105,4 +105,11 @@ public class AgentSessionProxy {
 //        logger.info("[isInvalidSessionId] result {}", result);
         return result;
     }
+
+    public void deleteUserSession(final String agentno, final String orgi) {
+        if (cache.existUserSessionByAgentnoAndOrgi(agentno, orgi)) {
+            logger.info("[deleteUserSession] agentno {}, orgi {}", agentno, orgi);
+            cache.deleteUserSessionByAgentnoAndOrgi(agentno, orgi);
+        }
+    }
 }


### PR DESCRIPTION
Destroy session after deleting user #781 

## 描述
When deleting a user, we also remove the `userSession` stored in`AgentSessionProxy` .  For doing this, we add `deleteUserSession` function in `AgentSessionProxy.class`. 

Moreover, when a request comes, we add the function to check whether this session is still valid in `UserInterceptorHandler`.

## 解决的问题
#781 CWE-613: Insufficient Session Expiration 已经被删除的用户，他的所有session应该立即无效

## 截屏
1. User1 login
<img width="1434" alt="image" src="https://user-images.githubusercontent.com/32480426/225198235-426f1e27-9fef-4f98-9aa4-6e4d6e031e24.png">

2.  Admin deletes User1;
<img width="1435" alt="image" src="https://user-images.githubusercontent.com/32480426/225198413-03e07aec-24b8-42b6-82fd-596edf5dbdab.png">
<img width="1437" alt="image" src="https://user-images.githubusercontent.com/32480426/225198415-dc49f459-25a6-4964-9b65-d625a191d583.png">

3. User1 cannot operate anymore.
<img width="1432" alt="image" src="https://user-images.githubusercontent.com/32480426/225198481-6027cc59-7e4d-435e-bccd-90faad4aebdc.png">
<img width="1379" alt="image" src="https://user-images.githubusercontent.com/32480426/225198512-837f8b7c-9108-44f3-bc4b-0fe4647ed7b5.png">



## 变更的类型
<!--- 变更有哪些特点，添加 `x` 到下面的对应项目中: -->
- [x] 解决Bug
- [ ] 新功能（不影响其他功能）
- [ ] 对其他功能有影响

## 检查:
<!--- 检查下面，各项，添加 `x` 到下面的对应项目中: -->
- [ ] 我的变更和代码规范一致
- [ ] 我的变更需要更新文档
- [ ] 我已经更新了对应的文档
- [ ] 我增加的代码有单元测试
- [ ] 所有单元测试都能通过
