### PR TITLE
把4个模板中对百度站点统计的默认协议由http改为https

### DIFF
--- a/contact-center/app/src/main/resources/static/js/kindeditor/plugins/baidumap/map.html
+++ b/contact-center/app/src/main/resources/static/js/kindeditor/plugins/baidumap/map.html
@@ -7,7 +7,7 @@
 			html { height: 100% }
 			body { height: 100%; margin: 0; padding: 0; background-color: #FFF }
 		</style>
-		<script charset="utf-8" src="http://api.map.baidu.com/api?v=1.3"></script>
+		<script charset="utf-8" src="https://api.map.baidu.com/api?v=1.3"></script>
 		<script>
 			var map, geocoder;
 			function initialize() {

--- a/contact-center/app/src/main/resources/templates/apps/include/layout.pug
+++ b/contact-center/app/src/main/resources/templates/apps/include/layout.pug
@@ -50,7 +50,7 @@ html(xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org" xm
                 script(src="/js/UKeFu-CallOut.js")
             script(src="/js/weixinAudio.js")
             if systemConfig && systemConfig.mapkey && systemConfig.mapkey != ''
-                script(src="http://api.map.baidu.com/api?v=2.0&ak=" + systemConfig.mapkey)
+                script(src="https://api.map.baidu.com/api?v=2.0&ak=" + systemConfig.mapkey)
             script(src="/js/echarts.common.min.js")
             script(language="javascript" src="/js/theme/wonderland.js")
             if userExpTelemetry == 'on'

--- a/contact-center/app/src/main/resources/templates/apps/include/tpl.html
+++ b/contact-center/app/src/main/resources/templates/apps/include/tpl.html
@@ -45,7 +45,7 @@
 	
 	<script src="/js/weixinAudio.js"></script>
 	<#if systemConfig?? && systemConfig.mapkey?? && systemConfig.mapkey!=''>
-	<script type="text/javascript" src="http://api.map.baidu.com/api?v=2.0&ak=${systemConfig.mapkey}"></script>
+	<script type="text/javascript" src="https://api.map.baidu.com/api?v=2.0&ak=${systemConfig.mapkey}"></script>
 	</#if>
 	
 	<script src="/js/echarts.common.min.js"></script>

--- a/contact-center/app/src/main/resources/templates/apps/index.pug
+++ b/contact-center/app/src/main/resources/templates/apps/index.pug
@@ -52,7 +52,7 @@ html(xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org" xm
         script(src="/js/ace/theme-chrome.js" type="text/javascript" charset="utf-8")
         script(src="/js/weixinAudio.js")
         if systemConfig.mapkey
-            script(type="text/javascript" src="http://api.map.baidu.com/api?v=2.0&ak=" + systemConfig.mapkey)
+            script(type="text/javascript" src="https://api.map.baidu.com/api?v=2.0&ak=" + systemConfig.mapkey)
         style.
             .ztree li span {
                 display: inline-block !important;


### PR DESCRIPTION
<!--- 在标题中简略说明问题 -->

## 描述
采用https的网站所使用的http协议会被拦截或提示不安全的链接。

## 解决的问题
把4个模板中对百度站点统计的默认协议由http改为https
(https://github.com/cskefu/cskefu/issues/816)](https://github.com/cskefu/cskefu/issues/816)

## 测试情况
菜鸟级pr，从issues#816中来。

## 截屏

## 变更的类型
<!--- 变更有哪些特点，添加 `x` 到下面的对应项目中: -->
- [ x] 解决Bug
- [ ] 新功能（不影响其他功能）
- [ ] 对其他功能有影响

## 检查:
- [ x] 我的变更和代码规范一致

