### PR TITLE
#758 update codeowners for v8

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
 # https://github.com/cskefu/cskefu/issues/758
 
 # defaults
-*       @cskefu/reviewers
+*       @lecjy
 
 # Order is important; the last matching pattern takes the most
 # precedence. When someone opens a pull request that only
@@ -12,7 +12,7 @@
 *.pug   @lecjy
 *.java  @lecjy
 *.sql   @lecjy
-pom.xml @lecjy
+pom.xml @hailiang-wang
 
-docs/*  @SAMZONG
-README* @SAMZONG
+docs/*  @cskefu/reviewers
+README* @cskefu/reviewers


### PR DESCRIPTION



<!--- 在标题中简略说明问题 -->

设置 v8 默认的 PR Reviewers 自动分配方案。
见：https://github.com/hailiang-wang/cskefu/blob/develop/.github/CODEOWNERS


## 描述
<!--- 详细的描述变更 -->


## 解决的问题
<!--- 为什么变更是必要的？ -->
<!--- 如果这个PR解决了其他Issue，添加链接 -->

关联 #758
## 测试情况
<!--- 详细介绍怎么测试变更了 -->
<!--- 介绍测试环境 -->
<!--- 变更对其他代码的影响 -->

## 截屏

## 变更的类型
<!--- 变更有哪些特点，添加 `x` 到下面的对应项目中: -->
- [ ] 解决Bug
- [x] 新功能（不影响其他功能）
- [ ] 对其他功能有影响

## 检查:
<!--- 检查下面，各项，添加 `x` 到下面的对应项目中: -->
- [x] 我的变更和代码规范一致
- [ ] 我的变更需要更新文档
- [ ] 我已经更新了对应的文档
- [ ] 我增加的代码有单元测试
- [ ] 所有单元测试都能通过
