### PR TITLE
#794 调整服务类型点击为空，对后端返回值tags赋值逻辑进行修改，目前修改的逻辑为：查询同机构下，类型为ccsummry 下的服务类型

### DIFF
--- a/contact-center/app/src/main/java/com/cskefu/cc/controller/apps/AgentController.java
+++ b/contact-center/app/src/main/java/com/cskefu/cc/controller/apps/AgentController.java
@@ -1020,12 +1020,14 @@
                      map.addAttribute("summary", summaries.get(0));
                  }
              }
-             AgentService service = agentServiceRes.findById(agentserviceid).orElse(null);
-             if (service != null) {
+             Organ currentOrgan = super.getOrgan(request);
+             if(null!=currentOrgan){
                  map.addAttribute(
                          "tags", tagRes.findByTagtypeAndSkill(
-                                 MainContext.ModelType.SUMMARY.toString(), service.getSkill()));
+                                 MainContext.ModelType.CCSUMMARY.toString(), currentOrgan.getParent()));
              }
+			 
+			 
              map.addAttribute("userid", userid);
              map.addAttribute("agentserviceid", agentserviceid);
              map.addAttribute("agentuserid", agentuserid);


### PR DESCRIPTION
<!--- 在标题中简略说明问题 -->

## 描述
<!--- 详细的描述变更 -->
服务类型点击为空

## 解决的问题
<!--- 为什么变更是必要的？ -->
<!--- 如果这个PR解决了其他Issue，添加链接 -->
由于服务类型是必填项，现在为空，导致无法提交服务小结

## 测试情况
<!--- 详细介绍怎么测试变更了 -->
<!--- 介绍测试环境 -->
<!--- 变更对其他代码的影响 -->

本地搭建的开发环境，进行本地修改，测试通过
## 截屏
![image](https://github.com/cskefu/cskefu/assets/32507511/0628bdf0-8340-4091-8d7a-20e944eba073)


## 变更的类型
<!--- 变更有哪些特点，添加 `x` 到下面的对应项目中: -->
- [x] 解决Bug
- [ ] 新功能（不影响其他功能）
- [ ] 对其他功能有影响

## 检查:
<!--- 检查下面，各项，添加 `x` 到下面的对应项目中: -->
- [x] 我的变更和代码规范一致
- [ ] 我的变更需要更新文档
- [ ] 我已经更新了对应的文档
- [ ] 我增加的代码有单元测试
- [x] 所有单元测试都能通过
