### PR TITLE
#I8F61B 联系人查询，类别字段新增判空处理

### DIFF
--- a/contact-center/app/src/main/java/com/cskefu/cc/persistence/repository/ContactsRepository.java
+++ b/contact-center/app/src/main/java/com/cskefu/cc/persistence/repository/ContactsRepository.java
@@ -50,7 +50,7 @@ public interface ContactsRepository extends JpaRepository<Contacts, String> {
      * @param pageRequest
      * @return
      */
-    @Query("select c from Contacts c where c.organ IN :organs and c.ckind = :ckind AND c.shares = 'all' AND c.datastatus = false")
+    @Query("select c from Contacts c where c.organ IN :organs and (:ckind IS NULL OR c.ckind = :ckind) AND c.shares = 'all' AND c.datastatus = false")
     Page<Contacts> findByOrganInAndCkindAndSharesAllAndDatastatusFalse(@Param("organs") Collection<String> organs, @Param("ckind") String ckind, Pageable pageRequest);
 
     Page<Contacts> findByDatastatus(boolean b, Pageable pageRequest);


### PR DESCRIPTION
## 描述

此问题是在gitee上提交的issues ，时间于2023-11-13  社区开发者 进行修改提交，通过代码查阅，我发现如果点击选择全部联系人，查询为空，但点击其他类别是有联系人信息内容，这部分逻辑不完善

## 解决问题
逻辑进行完善，选择全部联系人，查询正常

## 测试情况
本地环境已验证

![image](https://github.com/cskefu/cskefu/assets/32507511/1f11ef50-515b-4fc1-bdfc-50381be574a6)
![image](https://github.com/cskefu/cskefu/assets/32507511/9a67268d-d4dd-4540-b90b-8f0e724bfe2f)

