### PR TITLE
fix 任意文件读取

### DIFF
--- a/contact-center/app/src/main/java/com/cskefu/cc/controller/resource/MediaController.java
+++ b/contact-center/app/src/main/java/com/cskefu/cc/controller/resource/MediaController.java
@@ -166,7 +166,7 @@ public class MediaController extends Handler {
     @RequestMapping("/template")
     @Menu(type = "resouce", subtype = "template")
     public void template(HttpServletResponse response, HttpServletRequest request, @Valid String filename) throws IOException {
-        if (StringUtils.isNotBlank(filename)) {
+        if (StringUtils.isNotBlank(filename) && !(filename.contains("../") || filename.contains("..\\"))) {
             InputStream is = MediaController.class.getClassLoader().getResourceAsStream(TEMPLATE_DATA_PATH + filename);
             if (is != null) {
                 response.setContentType("text/plain");


### PR DESCRIPTION
http://ip:port/res/template?filename=../../../application.properties

![image](https://github.com/cskefu/cskefu/assets/105204993/da990ade-ac2a-46fa-914e-b30bb6d2d55f)

未修复时候，可以跨目录读取配置文件