### PR TITLE
feat: 使用前后缀来避免不同 profile 共用 ActiveMQ 实例引发的消息路由错乱问题

### DIFF
--- a/contact-center/app/src/main/java/com/cskefu/cc/activemq/AgentAuditSubscription.java
+++ b/contact-center/app/src/main/java/com/cskefu/cc/activemq/AgentAuditSubscription.java
@@ -54,7 +54,7 @@ public class AgentAuditSubscription {
      *
      * @param msg
      */
-    @JmsListener(destination = Constants.AUDIT_AGENT_MESSAGE, containerFactory = "jmsListenerContainerTopic")
+    @JmsListener(destination = "${cskefu.activemq.destination.prefix}" + Constants.AUDIT_AGENT_MESSAGE + "${cskefu.activemq.destination.suffix}", containerFactory = "jmsListenerContainerTopic")
     public void onMessage(final String msg) {
         logger.info("[onMessage] payload {}", msg);
         try {

--- a/contact-center/app/src/main/java/com/cskefu/cc/activemq/AgentSessionSubscription.java
+++ b/contact-center/app/src/main/java/com/cskefu/cc/activemq/AgentSessionSubscription.java
@@ -31,7 +31,7 @@ public class AgentSessionSubscription {
      *
      * @param msg
      */
-    @JmsListener(destination = Constants.MQ_TOPIC_WEB_SESSION_SSO, containerFactory = "jmsListenerContainerTopic")
+    @JmsListener(destination = "${cskefu.activemq.destination.prefix}" + Constants.MQ_TOPIC_WEB_SESSION_SSO + "${cskefu.activemq.destination.suffix}", containerFactory = "jmsListenerContainerTopic")
     public void onMessage(final String msg) {
         logger.info("[onMessage] payload {}", msg);
         try {

--- a/contact-center/app/src/main/java/com/cskefu/cc/activemq/AgentSubscription.java
+++ b/contact-center/app/src/main/java/com/cskefu/cc/activemq/AgentSubscription.java
@@ -48,7 +48,7 @@ public class AgentSubscription {
         brokerPublisher.send(Constants.INSTANT_MESSAGING_MQ_TOPIC_AGENT, j.toString(), true);
     }
 
-    @JmsListener(destination = Constants.INSTANT_MESSAGING_MQ_TOPIC_AGENT, containerFactory = "jmsListenerContainerTopic")
+    @JmsListener(destination = "${cskefu.activemq.destination.prefix}" + Constants.INSTANT_MESSAGING_MQ_TOPIC_AGENT + "${cskefu.activemq.destination.suffix}", containerFactory = "jmsListenerContainerTopic")
     public void onMessage(final String payload) {
         logger.info("[onMessage] payload {}", payload);
         JsonParser parser = new JsonParser();

--- a/contact-center/app/src/main/java/com/cskefu/cc/activemq/BlackListEventSubscription.java
+++ b/contact-center/app/src/main/java/com/cskefu/cc/activemq/BlackListEventSubscription.java
@@ -1,14 +1,14 @@
-/* 
- * Copyright (C) 2023 Beijing Huaxia Chunsong Technology Co., Ltd. 
- * <https://www.chatopera.com>, Licensed under the Chunsong Public 
+/*
+ * Copyright (C) 2023 Beijing Huaxia Chunsong Technology Co., Ltd.
+ * <https://www.chatopera.com>, Licensed under the Chunsong Public
  * License, Version 1.0  (the "License"), https://docs.cskefu.com/licenses/v1.html
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * Copyright (C) 2019-2022 Chatopera Inc, <https://www.chatopera.com>, 
- * Licensed under the Apache License, Version 2.0, 
+ * Copyright (C) 2019-2022 Chatopera Inc, <https://www.chatopera.com>,
+ * Licensed under the Apache License, Version 2.0,
  * http://www.apache.org/licenses/LICENSE-2.0
  */
 package com.cskefu.cc.activemq;
@@ -43,7 +43,7 @@ public class BlackListEventSubscription {
      *
      * @param payload
      */
-    @JmsListener(destination = Constants.WEBIM_SOCKETIO_ONLINE_USER_BLACKLIST, containerFactory = "jmsListenerContainerQueue")
+    @JmsListener(destination = "${cskefu.activemq.destination.prefix}" + Constants.WEBIM_SOCKETIO_ONLINE_USER_BLACKLIST + "${cskefu.activemq.destination.suffix}", containerFactory = "jmsListenerContainerQueue")
     public void onMessage(final String payload) {
         logger.info("[onMessage] payload {}", payload);
 

--- a/contact-center/app/src/main/java/com/cskefu/cc/activemq/OnlineUserSubscription.java
+++ b/contact-center/app/src/main/java/com/cskefu/cc/activemq/OnlineUserSubscription.java
@@ -17,14 +17,13 @@ import com.cskefu.cc.socketio.client.NettyClients;
 import com.cskefu.cc.util.SerializeUtil;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import jakarta.annotation.PostConstruct;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.jms.annotation.JmsListener;
 import org.springframework.stereotype.Component;
-
-import jakarta.annotation.PostConstruct;
 
 /**
  * IM OnlineUser
@@ -57,7 +56,7 @@ public class OnlineUserSubscription {
 
     }
 
-    @JmsListener(destination = Constants.INSTANT_MESSAGING_MQ_TOPIC_ONLINEUSER, containerFactory = "jmsListenerContainerTopic")
+    @JmsListener(destination = "${cskefu.activemq.destination.prefix}" + Constants.INSTANT_MESSAGING_MQ_TOPIC_ONLINEUSER + "${cskefu.activemq.destination.suffix}", containerFactory = "jmsListenerContainerTopic")
     public void onMessage(final String payload){
         logger.info("[onMessage] payload {}", payload);
         JsonParser parser = new JsonParser();

--- a/contact-center/app/src/main/java/com/cskefu/cc/activemq/SocketioConnEventSubscription.java
+++ b/contact-center/app/src/main/java/com/cskefu/cc/activemq/SocketioConnEventSubscription.java
@@ -22,6 +22,7 @@ import com.cskefu.cc.model.AgentStatus;
 import com.cskefu.cc.persistence.repository.AgentStatusRepository;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import jakarta.annotation.PostConstruct;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -29,7 +30,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.jms.annotation.JmsListener;
 import org.springframework.stereotype.Component;
 
-import jakarta.annotation.PostConstruct;
 import java.util.Date;
 
 /**
@@ -60,7 +60,7 @@ public class SocketioConnEventSubscription {
         logger.info("ActiveMQ Subscription is setup successfully.");
     }
 
-    @JmsListener(destination = Constants.WEBIM_SOCKETIO_AGENT_DISCONNECT, containerFactory = "jmsListenerContainerQueue")
+    @JmsListener(destination = "${cskefu.activemq.destination.prefix}" + Constants.WEBIM_SOCKETIO_AGENT_DISCONNECT + "${cskefu.activemq.destination.suffix}", containerFactory = "jmsListenerContainerQueue")
     public void onMessage(final String payload) {
         logger.info("[onMessage] payload {}", payload);
 

--- a/contact-center/app/src/main/java/com/cskefu/cc/plugins/chatbot/ChatbotEventSubscription.java
+++ b/contact-center/app/src/main/java/com/cskefu/cc/plugins/chatbot/ChatbotEventSubscription.java
@@ -80,7 +80,7 @@ public class ChatbotEventSubscription {
      *
      * @param payload
      */
-    @JmsListener(destination = Constants.INSTANT_MESSAGING_MQ_QUEUE_CHATBOT, containerFactory = "jmsListenerContainerQueue")
+    @JmsListener(destination = "${cskefu.activemq.destination.prefix}" + Constants.INSTANT_MESSAGING_MQ_QUEUE_CHATBOT + "${cskefu.activemq.destination.suffix}", containerFactory = "jmsListenerContainerQueue")
     public void onMessage(final String payload) {
         ChatMessage message = SerializeUtil.deserialize(payload);
         try {
@@ -238,7 +238,7 @@ public class ChatbotEventSubscription {
                             for (int i = 0; i < faqReplies.length(); i++) {
                                 JSONObject sugg = new JSONObject();
                                 JSONObject faqReply = faqReplies.getJSONObject(i);
-                                sugg.put("label", Integer.toString(i + 1) + ". " + faqReply.getString("post"));
+                                sugg.put("label", i + 1 + ". " + faqReply.getString("post"));
                                 sugg.put("text", faqReply.getString("post"));
                                 sugg.put("type", "qlist");
                                 suggs.put(sugg);

--- a/contact-center/app/src/main/java/com/cskefu/cc/plugins/messenger/MessengerEventSubscription.java
+++ b/contact-center/app/src/main/java/com/cskefu/cc/plugins/messenger/MessengerEventSubscription.java
@@ -43,7 +43,7 @@ public class MessengerEventSubscription {
     @Autowired
     private MessengerMessageProxy messengerMessageProxy;
 
-    @JmsListener(destination = Constants.INSTANT_MESSAGING_MQ_QUEUE_FACEBOOK_OTN, containerFactory = "jmsListenerContainerQueue")
+    @JmsListener(destination = "${cskefu.activemq.destination.prefix}" + Constants.INSTANT_MESSAGING_MQ_QUEUE_FACEBOOK_OTN + "${cskefu.activemq.destination.suffix}", containerFactory = "jmsListenerContainerQueue")
     public void onPublish(final String jsonStr) {
         JSONObject payload = JSONObject.parseObject(jsonStr);
         String otnId = payload.getString("otnId");

--- a/contact-center/app/src/main/resources/application.properties
+++ b/contact-center/app/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2017 \u4F18\u5BA2\u670D-\u591A\u6E20\u9053\u5BA2\u670D\u7CFB\u7EDF
+# Copyright (C) 2017 优客服-多渠道客服系统
 # Modifications copyright (C) 2018-2022 Chatopera Inc, <https://www.chatopera.com>
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -48,7 +48,7 @@ server.tomcat.max-swallow-size=1000000000
 server.tomcat.max-threads=400
 
 ##############################################
-# \u65E5\u5FD7\u53CA\u4E34\u65F6\u6587\u4EF6\u5B58\u50A8
+# 日志及临时文件存储
 ##############################################
 server.log.path=../logs
 server.log.level=INFO
@@ -109,7 +109,7 @@ spring.activemq.user=admin
 spring.activemq.password=admin
 spring.activemq.pool.enabled=true
 spring.activemq.pool.max-connections=50
-# \u4F7F\u7528\u524D\u540E\u7F00\u6765\u907F\u514D\u4E0D\u540C profile \u5171\u7528 ActiveMQ \u5B9E\u4F8B\u5F15\u53D1\u7684\u6D88\u606F\u8DEF\u7531\u9519\u4E71\u95EE\u9898
+# 使用前后缀来避免不同 profile 共用 ActiveMQ 实例引发的消息路由错乱问题
 cskefu.activemq.destination.prefix=
 cskefu.activemq.destination.suffix=
 

--- a/contact-center/app/src/main/resources/application.properties
+++ b/contact-center/app/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2017 优客服-多渠道客服系统
+# Copyright (C) 2017 \u4F18\u5BA2\u670D-\u591A\u6E20\u9053\u5BA2\u670D\u7CFB\u7EDF
 # Modifications copyright (C) 2018-2022 Chatopera Inc, <https://www.chatopera.com>
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -48,7 +48,7 @@ server.tomcat.max-swallow-size=1000000000
 server.tomcat.max-threads=400
 
 ##############################################
-# 日志及临时文件存储
+# \u65E5\u5FD7\u53CA\u4E34\u65F6\u6587\u4EF6\u5B58\u50A8
 ##############################################
 server.log.path=../logs
 server.log.level=INFO
@@ -109,6 +109,9 @@ spring.activemq.user=admin
 spring.activemq.password=admin
 spring.activemq.pool.enabled=true
 spring.activemq.pool.max-connections=50
+# \u4F7F\u7528\u524D\u540E\u7F00\u6765\u907F\u514D\u4E0D\u540C profile \u5171\u7528 ActiveMQ \u5B9E\u4F8B\u5F15\u53D1\u7684\u6D88\u606F\u8DEF\u7531\u9519\u4E71\u95EE\u9898
+cskefu.activemq.destination.prefix=
+cskefu.activemq.destination.suffix=
 
 ##############################################
 # Actuator


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/fda682bd-62c2-4557-973e-95994e9c3dd0)
